### PR TITLE
Reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ endif
 LDFLAGS += -X github.com/infuseai/artivc/cmd.tagVersion=${VERSION}
 LDFLAGS += -X github.com/infuseai/artivc/cmd.gitCommit=${GIT_COMMIT}
 LDFLAGS += -X github.com/infuseai/artivc/cmd.gitTreeState=${GIT_DIRTY}
+LDFLAGS += -s -w
 LDFLAGS += $(EXT_LDFLAGS)
 
 


### PR DESCRIPTION
Add linker flags `-s` and `-w` to reduce binary size by removing debug and DWARF symbols

Saved around 6M before compression.

Ref: https://pkg.go.dev/cmd/link

> -s
>     Omit the symbol table and debug information.
> -w
>     Omit the DWARF symbol table.


## Comparison

```bash
# Before
$ go build -o bin/avc -ldflags ' -X github.com/infuseai/artivc/cmd.tagVersion= -X github.com/infuseai/artivc/cmd.gitCommit=6895c74b6ca090770e0338447bf62d2c7a2bb1e3 -X github.com/infuseai/artivc/cmd.gitTreeState=clean ' main.go
$ stat -f%z bin/avc
29522322

# After
$ go build -o bin/avc -ldflags ' -X github.com/infuseai/artivc/cmd.tagVersion= -X github.com/infuseai/artivc/cmd.gitCommit=6895c74b6ca090770e0338447bf62d2c7a2bb1e3 -X github.com/infuseai/artivc/cmd.gitTreeState=dirty -s -w ' main.go
$ stat -f%z bin/avc
23132178
```

Signed-off-by: Ash Wu <hSATAC@gmail.com>